### PR TITLE
Update ember-cli-babel version to 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^6.8.2",
     "raf-measure": "0.0.11"
   },
   "ember-addon": {


### PR DESCRIPTION
Updating ember-cli-babel version to 6.x to remove deprecated warnings related to ember-cli-babel 5.x